### PR TITLE
Support for custom Wasm Plugin image

### DIFF
--- a/operators/templates/kuadrant/04-subscription.yaml
+++ b/operators/templates/kuadrant/04-subscription.yaml
@@ -21,7 +21,11 @@ spec:
     env:
       - name: "AUTH_SERVICE_TIMEOUT"
         value: "1000ms"
-{{- if eq .Values.istio.istioProvider "ocp"}}
+{{- if eq .Values.istio.istioProvider "ocp" }}
       - name: "ISTIO_GATEWAY_CONTROLLER_NAMES"
         value: "openshift.io/gateway-controller/v1"
-{{- end}}
+{{- end }}
+{{- if .Values.kuadrant.wasmPluginImage }}
+      - name: "RELATED_IMAGE_WASMSHIM"
+        value: {{ .Values.kuadrant.wasmPluginImage }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -42,6 +42,13 @@ kuadrant:
   # kuadrant-operator.v1.2.0
   startingCSV: "kuadrant-operator.v0.0.0"
 
+  # (optional)
+  # If specified it will be used as a value for RELATED_IMAGE_WASMSHIM env var
+  # Examples:
+  # registry.redhat.io/rhcl-1/wasm-shim-rhel9@sha256:845bb8af57f3d219aa09b9c0bb20fa945306f3b413e34e196760c8cdf624a532
+  # oci://quay.io/kuadrant/wasm-shim:9f114d4c725e4b81eab38306bace96547db18f71
+  wasmPluginImage: ""
+
 # Installs Gateway API CRD's on cluster. Not needed for Openshift 4.19+
 gatewayAPI:
   version: v1.3.0  # v1.0.0, v1.1.0, v1.2.1, v1.3.0 available; empty value will not create any CRD


### PR DESCRIPTION
## Overview

Adding support for specifying custom WASM SHIM Plugin image. Useful for testing purposes.

### Verification Steps

Execute the helm chart with `wasmPluginImage` specified and validate that the env var exists in Subscription and is populated with expected value. Alternatively you can take a look at provision-install-test pipeline run  in my namespace - I used it to validate this myself, just check the logs of helm-install task run.

(Optional) Execute the helm chart with `wasmPluginImage` not specified and validate that the env var is not defined in Subscription