### PR TITLE
Using multiarch manifests in tools

### DIFF
--- a/values-tools.yaml
+++ b/values-tools.yaml
@@ -5,7 +5,7 @@ tools:
     image: quay.io/jaegertracing/all-in-one
   mockserver:
     enable: true
-    image: quay.io/trepel/mockserver:mganisin
+    image: quay.io/rhn_support_azgabur/mockserver:latest
   keycloak:
     enable: true
     # 'operator' for RHBK operator
@@ -18,7 +18,7 @@ tools:
     deployment:
       image: quay.io/keycloak/keycloak:26.3
     database:
-      image: quay.io/sclorg/postgresql-16-c10s
+      image: registry.redhat.io/rhel9/postgresql-16
   redis:
     enable: true
     image: quay.io/opstree/redis:latest


### PR DESCRIPTION
## Overview

In order to get ready for ARM infrastructure the images used in tools need to be multi-architecture manifests rather than single single-architecture images.

Closes #34 

### Verification Steps

Install tools from this PR on cluster and run smoke tests against it. You can also try to pull the ARM image:
`podman pull --platform linux/arm64 <one-of-the-changed-pull-specs>`