### PR TITLE
Split CoreDNS service into separate TCP/UDP services

### DIFF
--- a/charts/tools-instances/templates/coredns/03-service.yaml
+++ b/charts/tools-instances/templates/coredns/03-service.yaml
@@ -2,8 +2,30 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: coredns
+  name: coredns-tcp
   namespace: {{ .Values.tools.namespace }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+  labels:
+    app: coredns
+spec:
+  selector:
+    app: coredns
+  ports:
+    - name: "tcp-53"
+      protocol: TCP
+      port: 53
+      targetPort: "tcp-53"
+  type: LoadBalancer
+  externalTrafficPolicy: Local
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-udp
+  namespace: {{ .Values.tools.namespace }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
   labels:
     app: coredns
 spec:
@@ -14,10 +36,6 @@ spec:
       protocol: UDP
       port: 53
       targetPort: "udp-53"
-    - name: "tcp-53"
-      protocol: TCP
-      port: 53
-      targetPort: "tcp-53"
   type: LoadBalancer
   externalTrafficPolicy: Local
 ---


### PR DESCRIPTION
## Overview

Split CoreDNS Service into two separate services for TCP and UDP protocols respectively. Reason is that  single Service does not work (Location stuck in "Pending") on AWS and GCP (these two cloud providers do not support mixing protocols in LoadBalancers).

Specific AWS annotation has been added so that new type (Network) of load balancer is used - even after split it didn't work.

### Verification Steps

This coreDNS stuff is not yet used by testsuite so eye review only. If you want to be thorough then get 4 clusters (on Openstack, AWS, GCP, ARO) and install tools (`./tools-install.sh`) on each (but I did that). It should finish successfully.