### PR TITLE
Add yaml values files into github release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main ]
     paths:
       - 'charts/**'
+      - 'values-tools.yaml'
+      - 'values.yaml'
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add YAML values files to GitHub release CI trigger paths to ensure Helm chart releases are properly triggered when root-level values files are modified.

## Changes

- **`.github/workflows/release.yml`**: Added `values-tools.yaml` and `values.yaml` to the CI trigger paths alongside existing `charts/**` path

## Background

The GitHub release workflow was only monitoring changes in the `charts/` directory, but the repository also contains root-level values files (`values.yaml` and `values-tools.yaml`) that are used for Helm chart deployments. This change ensures that modifications to these values files will also trigger the Helm chart release process.

## Verification Steps

Eye review is sufficient - the change is minimal and only adds two file paths to the existing CI trigger configuration.