### PR TITLE
Specify controller name for upstream only

### DIFF
--- a/charts/kuadrant-operators/templates/kuadrant/05-subscription.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/05-subscription.yaml
@@ -22,7 +22,7 @@ spec:
     env:
       - name: "AUTH_SERVICE_TIMEOUT"
         value: "1000ms"
-{{- if eq .Values.istio.istioProvider "ocp" }}
+{{- if and (eq .Values.istio.istioProvider "ocp") (eq .Values.kuadrant.operatorName "kuadrant-operator") }}
       - name: "ISTIO_GATEWAY_CONTROLLER_NAMES"
         value: "openshift.io/gateway-controller/v1"
 {{- end }}


### PR DESCRIPTION
## Overview

Specifying controller name for OCP v4.19+ via environment variable is no longer required for downstream. See https://issues.redhat.com/browse/CONNLINK-433 and/or https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.1/html-single/release_notes_for_connectivity_link_1.1/index#fixed_issues

It is still required for upstream though.

## Verification Steps
Use OCP v4.19+ cluster and install Kuadrant (v1.3.0) and RHCL (1.1.1) there. Execute some test (the test must use Gateway), e.g.:
`make testsuite/tests/singlecluster/authorino/identity/anonymous/test_anonymous_identity.py`