### PR TITLE
Add protected registry support and update to v1.3.0

### DIFF
--- a/charts/kuadrant-operators/templates/kuadrant/05-subscription.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/05-subscription.yaml
@@ -30,4 +30,11 @@ spec:
       - name: "RELATED_IMAGE_WASMSHIM"
         value: {{ .Values.kuadrant.wasmPluginImage }}
 {{- end }}
+{{- if and .Values.kuadrant.wasmPluginImage .Values.kuadrant.protectedRegistry }}
+    {{- if not (hasPrefix .Values.kuadrant.protectedRegistry .Values.kuadrant.wasmPluginImage) }}
+    {{- fail "protectedRegistry must match the registry in wasmPluginImage" }}
+    {{- end }}
+      - name: "PROTECTED_REGISTRY"
+        value: {{ .Values.kuadrant.protectedRegistry }}
+{{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@ kuadrant:
   # OLM index image to use for kuadrant deployment, creates CatalogSource CR with this image
   # If left empty it uses CatalogSource defined in catalogSource
   # For list of available upstream CatalogSource's see https://quay.io/repository/kuadrant/kuadrant-operator-catalog?tab=tags
-  indexImage: 'quay.io/kuadrant/kuadrant-operator-catalog:v1.2.0'
+  indexImage: 'quay.io/kuadrant/kuadrant-operator-catalog:v1.3.0'
 
   # (optional)
   # Name of pull secret for pulling indexImage if needed. Can be left empty.
@@ -44,11 +44,18 @@ kuadrant:
   startingCSV: "kuadrant-operator.v0.0.0"
 
   # (optional)
-  # If specified it will be used as a value for RELATED_IMAGE_WASMSHIM env var
-  # Examples:
-  # registry.redhat.io/rhcl-1/wasm-shim-rhel9@sha256:845bb8af57f3d219aa09b9c0bb20fa945306f3b413e34e196760c8cdf624a532
-  # oci://quay.io/kuadrant/wasm-shim:9f114d4c725e4b81eab38306bace96547db18f71
+  # If specified, these will be used as values for RELATED_IMAGE_WASMSHIM and PROTECTED_REGISTRY env vars respectively.
+  # Example values would be
+  # "registry.stage.redhat.io/rhcl-1/wasm-shim-rhel9@sha256:c78019c49f4f2d03da9df6e2711585333a7b4a409011d105bdaab3b391ef7670"
+  # and
+  # "registry.stage.redhat.io"
+  # respectively.
+  # If protected registry is not used leave the protectedRegistry empty.
+  # If protected registry is used the protectedRegistry value must be the same as a registry of wasmPluginImage.
+  # IMPORTANT: When using protectedRegistry, ensure that a pull secret named
+  # 'wasm-plugin-pull-secret' exists in the Gateway namespace before deployment.
   wasmPluginImage: ""
+  protectedRegistry: ""
 
 # Installs Gateway API CRD's on cluster. Not needed for Openshift 4.19+
 gatewayAPI:


### PR DESCRIPTION
## Overview

The PROTECTED_REGISTRY env var must be set for `wasm-plugin-pull-secret` to be actually used, see
https://github.com/Kuadrant/kuadrant-operator/blob/c4d2bba75d0d4d084a13bbaceb396ed42a9b4283/internal/controller/data_plane_policies_workflow.go#L33-L36

Note: I intentionally left an option to specify `wasmPluginImage` without specifying `protectedRegistry` since I can imagine a use case where we want to test some changes in wasmshim image so we push it somewhere to public registry. The vice versa use case (default wasmPluginImage being in protected registry) should not happen and if yes it is more likely a bug rather than a feature.

This PR also updates the default Kuadrant operator catalog to v1.3.0.

## Verification Steps
Eye review.
If you want to be thorough run `./install.sh` against the cluster several times
- both `protectedRegistry` and `wasmPluginImage` empty (optional - there should not be any change in this case)
- both of them filled in - for that you need to have wasmPluginImage pushed in some private registry and create proper wasm-plugin-pull-secret
- both of them filled in but `protectedRegistry` is not the same as the one used in `wasmPluginImage`