### PR TITLE
Raise limitador timeouts

### DIFF
--- a/charts/kuadrant-operators/templates/kuadrant/05-subscription.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/05-subscription.yaml
@@ -22,6 +22,12 @@ spec:
     env:
       - name: "AUTH_SERVICE_TIMEOUT"
         value: "1000ms"
+      - name: "RATELIMIT_SERVICE_TIMEOUT"
+        value: "1000ms"
+      - name: "RATELIMIT_CHECK_SERVICE_TIMEOUT"
+        value: "1000ms"
+      - name: "RATELIMIT_REPORT_SERVICE_TIMEOUT"
+        value: "1000ms"
 {{- if and (eq .Values.istio.istioProvider "ocp") (eq .Values.kuadrant.operatorName "kuadrant-operator") }}
       - name: "ISTIO_GATEWAY_CONTROLLER_NAMES"
         value: "openshift.io/gateway-controller/v1"


### PR DESCRIPTION
Due to our slow infrasctrucutre we maybe need to raise the default limits which were set at `100ms`
Simillar reasoning to why we set `AUTH_SERVICE_TIMEOUT`

Found these env variables in: https://github.com/Kuadrant/kuadrant-operator/blob/main/internal/wasm/utils.go