### PR TITLE
Add configurable Kuadrant post-install hook for debug logging

### DIFF
--- a/charts/kuadrant-instances/templates/_helpers.tpl
+++ b/charts/kuadrant-instances/templates/_helpers.tpl
@@ -1,0 +1,127 @@
+{{/* Restarts Kuadrant Operator if needed. Waits for Kuadrant, Limitador and Authorino CRs and patch them to enable observability and debug logging if desired */}}
+{{- define "kuadrant.post-install-helm-hook" -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: post-install-helm-hook
+  namespace: {{ .namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: post-install-helm-hook-role
+  namespace: {{ .namespace }}
+rules:
+- apiGroups:
+  - kuadrant.io
+  resources:
+  - kuadrants
+  verbs:
+  - get
+  - patch
+  - list
+  - watch
+- apiGroups:
+  - limitador.kuadrant.io
+  resources:
+  - limitadors
+  verbs:
+  - get
+  - patch
+  - list
+  - watch
+- apiGroups:
+  - operator.authorino.kuadrant.io
+  resources:
+  - authorinos
+  verbs:
+  - get
+  - patch
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: post-install-helm-hook-rb
+  namespace: {{ .namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: post-install-helm-hook-role
+subjects:
+- kind: ServiceAccount
+  name: post-install-helm-hook
+  namespace: {{ .namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: post-install-helm-hook
+  namespace: {{ .namespace }}
+data:
+  "run.sh": |
+    #!/bin/bash
+    set -xe
+
+    # First restart Kuadrant operator if needed
+    MESSAGE=$(kubectl get kuadrant kuadrant-sample --namespace {{ .namespace }} -o jsonpath='{.status.conditions[*].message}')
+    if [[ "$MESSAGE" == *"please restart Kuadrant Operator pod"* ]]; then
+        kubectl delete pod -l app=kuadrant --wait=true --namespace {{ .namespace }}
+    fi
+    kubectl wait --for=condition=Ready kuadrant kuadrant-sample --namespace {{ .namespace }} --timeout=300s
+
+    ENABLE_DEBUG="{{ .enableDebug }}"
+    if [[ "$ENABLE_DEBUG" == "true" ]]; then
+        kubectl patch limitador limitador --namespace {{ .namespace }} --type merge --patch '{"spec":{"verbosity":3}}'
+        kubectl patch authorino authorino --namespace {{ .namespace }} --type merge --patch '{"spec":{"logLevel":"debug", "logMode": "development"}}'
+        kubectl wait --for=jsonpath={.status.observedGeneration}=$(kubectl get limitador limitador --namespace {{ .namespace }} -o jsonpath={.metadata.generation}) limitador limitador --namespace {{ .namespace }} --timeout=300s
+        kubectl wait --for=condition=Ready limitador limitador --namespace {{ .namespace }} --timeout=300s
+        # Authorino CR does not have `.status.observedGeneration` defined hence just this simple wait
+        kubectl wait --for=condition=Ready authorino authorino --namespace {{ .namespace }} --timeout=300s
+    fi
+
+    # Another wait for Kuadrant to get ready just to be on the safe side
+    kubectl wait --for=jsonpath={.status.observedGeneration}=$(kubectl get kuadrant kuadrant-sample --namespace {{ .namespace }} -o jsonpath={.metadata.generation}) kuadrant kuadrant-sample --namespace {{ .namespace }} --timeout=300s
+    kubectl wait --for=condition=Ready kuadrant kuadrant-sample --namespace {{ .namespace }} --timeout=300s
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: post-install-helm-hook
+  namespace: {{ .namespace }}
+  annotations:
+    "helm.sh/hook": post-install
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - /scripts/run.sh
+        image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+        name: post-install
+        volumeMounts:
+        - name: script-volume
+          mountPath: /scripts
+        resources: {}
+      volumes:
+        - name: script-volume
+          configMap:
+            name: post-install-helm-hook
+      serviceAccount: post-install-helm-hook
+      restartPolicy: OnFailure
+{{- end -}}

--- a/charts/kuadrant-instances/templates/kuadrant/01-kuadrant.yaml
+++ b/charts/kuadrant-instances/templates/kuadrant/01-kuadrant.yaml
@@ -4,5 +4,11 @@ kind: Kuadrant
 metadata:
   name: kuadrant-sample
   namespace: {{ .Values.kuadrant.namespace }}
+{{ if eq .Values.kuadrant.enableDebug true }}
+spec:
+  observability:
+    enable: true
+{{ else }}
 spec: {}
+{{ end }}
 {{ end }}

--- a/charts/kuadrant-instances/templates/kuadrant/02-post-hook.yaml
+++ b/charts/kuadrant-instances/templates/kuadrant/02-post-hook.yaml
@@ -1,0 +1,2 @@
+{{- $args := dict "namespace" .Values.kuadrant.namespace "enableDebug" .Values.kuadrant.enableDebug }}
+{{- include "kuadrant.post-install-helm-hook" $args }}

--- a/charts/kuadrant-operators/templates/kuadrant/06-subscription.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/06-subscription.yaml
@@ -45,6 +45,10 @@ spec:
       - name: "OTEL_METRICS_INTERVAL_SECONDS"
         value: "5"
 {{- end }}
+{{- if .Values.kuadrant.enableDebug }}
+      - name: "LOG_LEVEL"
+        value: "debug"
+{{- end }}
 {{- if and (eq .Values.istio.istioProvider "ocp") (eq .Values.kuadrant.operatorName "kuadrant-operator") }}
       - name: "ISTIO_GATEWAY_CONTROLLER_NAMES"
         value: "openshift.io/gateway-controller/v1"

--- a/values.yaml
+++ b/values.yaml
@@ -57,6 +57,9 @@ kuadrant:
   wasmPluginImage: ""
   protectedRegistry: ""
 
+  # Enable debug and observability for Kuadrant and its components
+  enableDebug: true
+
 # Installs Gateway API CRD's on cluster. Not needed for Openshift 4.19+
 gatewayAPI:
   version: v1.4.0  # v1.2.1, v1.3.0, v1.4.0 available; leave empty for installing on Openshift 4.19+


### PR DESCRIPTION
This PR introduces a Kuadrant post-install hook that enables debug logging and observability across Kuadrant stack components. When enabled, the hook:
  - Enables observability in Kuadrant CR
  - Sets verbosity level 3 for Limitador
  - Configures debug logging with development mode for Authorino

  The feature is controlled via values.kuadrant.enableDebug (defaulting to true since I think the CR patches make sense in most cases) and includes proper RBAC permissions and wait conditions to ensure resources are ready before and after patching.

This PR is reaction to https://github.com/Kuadrant/testsuite-pipelines/pull/135#discussion_r2440001913 even though it
- does not deal with tools.enabled renaming
- has it's own switch (.kuadrant.enableDebug) independent of .tools.enabled because I can't see why this should be tied to .tools.enabled

### Verification Steps
Install with .kuadrant.enableDebug set to 'true', then uninstall and install again with it to be set to 'false'.