### PR TITLE
Add lower default dns ttl for faster testing

### DIFF
--- a/charts/kuadrant-operators/templates/kuadrant/06-subscription.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/06-subscription.yaml
@@ -31,6 +31,10 @@ spec:
         value: "1000ms"
       - name: "RATELIMIT_REPORT_SERVICE_TIMEOUT"
         value: "1000ms"
+      - name: "DNS_DEFAULT_TTL"
+        value: "1"
+      - name: "DNS_DEFAULT_LB_TTL"
+        value: "1"
 {{- if .Values.enableTracing.enable }}
       - name: "OTEL_ENABLED"
         value: "true"


### PR DESCRIPTION
Will significantly speed up our testing. Will need some additional changes in testsuite by mainly reducing hard coded sleeps.
requires https://github.com/Kuadrant/kuadrant-operator/issues/1628