### PR TITLE
Add version freezing scripts and installation option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ set -e; set -o pipefail;
 cd "$(dirname "$0")"
 
 additional_flags=''
+tools_additional_flags=''
 
 if [[ "$1" == "-t" ]]; then
     additional_flags+=" --values additionalManifests.yaml --set tools.enabled=true"
@@ -13,6 +14,12 @@ fi
 
 if [[ "$INSTALL_RHCL_GA" == "true" ]]; then
     additional_flags+=" --set kuadrant.indexImage='' --set kuadrant.operatorName=rhcl-operator --set kuadrant.channel=stable"
+fi
+
+if [[ "$FREEZE_VERSIONS" == "true" ]]; then
+    script/get-all-versions.sh > "values-versions.yaml" || exit 1
+    additional_flags+=" --values values-versions.yaml"
+    tools_additional_flags+=" --values values-versions.yaml"
 fi
 
 echo "---Installing operators---"
@@ -25,10 +32,12 @@ eval "$helm_cmd"
 
 if [[ "$1" == "-t" ]]; then
 echo "--Installing tools operators"
-helm install --wait tools-operators charts/tools-operators
+helm_cmd="helm install $tools_additional_flags --wait tools-operators charts/tools-operators"
+eval "$helm_cmd"
 
 echo "--Installing tools instances"
-helm install --wait --timeout 10m tools-instances charts/tools-instances
+helm_cmd="helm install $tools_additional_flags --wait --timeout 10m tools-instances charts/tools-instances"
+eval "$helm_cmd"
 fi
 
 echo "Success!"

--- a/script/get-all-versions.sh
+++ b/script/get-all-versions.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+command -v jq || { echo "'jq' is required for running this script."; exit 1; }
+command -v opm || { echo "'opm' is required for running this script."; exit 1; }
+
 tmpdir=$(mktemp -d)
 trap "rm -rf $tmpdir" EXIT
 

--- a/script/get-all-versions.sh
+++ b/script/get-all-versions.sh
@@ -15,8 +15,8 @@ PID_IMAGES="$!"
 "${SCRIPT_DIR}/get-operator-versions.sh" > "$tmpdir/operators.yaml" &
 PID_OPERATORS="$!"
 
-wait "$PID_IMAGES" || { echo "ERROR: Images versions script failed" && exit 1; }
-wait "$PID_OPERATORS" || { echo "ERROR: Operator versions script failed" && exit 1; }
+wait "$PID_IMAGES" || { echo "ERROR: Images versions script failed" >&2 && exit 1; }
+wait "$PID_OPERATORS" || { echo "ERROR: Operator versions script failed" >&2 && exit 1; }
 
 # Merge and output YAML
 yq eval-all '. as $item ireduce ({}; . * $item)' "$tmpdir/tags.yaml" "$tmpdir/operators.yaml"

--- a/script/get-all-versions.sh
+++ b/script/get-all-versions.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Script combines collection of latest versions of operators and images used in values.yaml (values-tools.yaml) and
+# outputs newest frozen values
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+tmpdir=$(mktemp -d)
+trap "rm -rf $tmpdir" EXIT
+
+# Run both scripts in parallel
+"${SCRIPT_DIR}/get-images-versions.sh" > "$tmpdir/tags.yaml" &
+PID_IMAGES="$!"
+"${SCRIPT_DIR}/get-operator-versions.sh" > "$tmpdir/operators.yaml" &
+PID_OPERATORS="$!"
+
+wait "$PID_IMAGES" || { echo "ERROR: Images versions script failed" && exit 1; }
+wait "$PID_OPERATORS" || { echo "ERROR: Operator versions script failed" && exit 1; }
+
+# Merge and output YAML
+yq eval-all '. as $item ireduce ({}; . * $item)' "$tmpdir/tags.yaml" "$tmpdir/operators.yaml"

--- a/script/get-all-versions.sh
+++ b/script/get-all-versions.sh
@@ -19,4 +19,5 @@ wait "$PID_IMAGES" || { echo "ERROR: Images versions script failed" >&2 && exit 
 wait "$PID_OPERATORS" || { echo "ERROR: Operator versions script failed" >&2 && exit 1; }
 
 # Merge and output YAML
+echo "# Generated on: $(date -R)"
 yq eval-all '. as $item ireduce ({}; . * $item)' "$tmpdir/tags.yaml" "$tmpdir/operators.yaml"

--- a/script/get-images-versions.sh
+++ b/script/get-images-versions.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Requires jq
+# Script queries semantically newest tag and outputs frozen versions
+# Picks newest version as a version number which is semantically biggest
+
+set -euo pipefail
+
+get_token() {
+    local registry="$1"
+    local image="$2"
+    local auth_url token_response
+
+    case "$registry" in
+        quay.io)
+            auth_url="https://quay.io/v2/auth?service=quay.io&scope=repository:${image}:pull"
+            ;;
+        ghcr.io)
+            auth_url="https://ghcr.io/token?service=ghcr.io&scope=repository:${image}:pull"
+            ;;
+        docker.dragonflydb.io)
+            auth_url="https://ghcr.io/token?service=ghcr.io&scope=repository:${image}:pull"
+            ;;
+        *)
+            echo ""
+            return
+            ;;
+    esac
+
+    token_response=$(curl -s "$auth_url")
+    echo "$token_response" | jq -r '.token // .access_token // empty'
+}
+
+get_registry_url() {
+    local registry="$1"
+    case "$registry" in
+        docker.dragonflydb.io)
+            echo "ghcr.io"
+            ;;
+        *)
+            echo "$registry"
+            ;;
+    esac
+}
+
+fetch_all_tags() {
+    local base_url="$1"
+    local token="$2"
+    local url="${base_url}?n=100"
+    local all_tags=""
+    local response headers body next_link
+
+    while [[ -n "$url" ]]; do
+        if [[ -n "$token" ]]; then
+            response=$(curl -sS -D - -H "Authorization: Bearer $token" "$url")
+        else
+            response=$(curl -sS -D - "$url")
+        fi
+
+        headers=$(echo "$response" | sed '/^\r$/q')
+        body=$(echo "$response" | sed '1,/^\r$/d')
+
+        tags=$(echo "$body" | jq -r '.tags[]' 2>/dev/null || true)
+        all_tags="${all_tags}"$'\n'"${tags}"
+
+        next_link=$(echo "$headers" | grep -i '^link:' | grep -oP '(?<=<)[^>]+(?=>; rel="next")' || true)
+        if [[ -n "$next_link" ]]; then
+            if [[ "$next_link" =~ ^https?:// ]]; then
+                url="$next_link"
+            else
+                url="${base_url%%/v2/*}${next_link}"
+            fi
+        else
+            url=""
+        fi
+    done
+
+    echo "$all_tags"
+}
+
+get_latest_tag() {
+    local full_image="$1"
+    local registry image token tags latest actual_registry base_url
+
+    registry="${full_image%%/*}"
+    image="${full_image#*/}"
+
+    token=$(get_token "$registry" "$image")
+    actual_registry=$(get_registry_url "$registry")
+    base_url="https://${actual_registry}/v2/${image}/tags/list"
+
+    tags=$(fetch_all_tags "$base_url" "$token")
+
+    latest=$(echo "$tags" | \
+        grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | \
+        sed 's/^v//' | \
+        sort -t. -k1,1n -k2,2n -k3,3n | \
+        tail -1)
+
+    if echo "$tags" | grep -qE "^v${latest}$"; then
+        latest="v${latest}"
+    fi
+
+    echo "$latest"
+}
+
+# Fetch all tags in parallel
+tmpdir=$(mktemp -d)
+trap "rm -rf $tmpdir" EXIT
+
+get_latest_tag "quay.io/opstree/redis" > "$tmpdir/redis" &
+get_latest_tag "docker.dragonflydb.io/dragonflydb/dragonfly" > "$tmpdir/dragonfly" &
+get_latest_tag "ghcr.io/valkey-io/valkey" > "$tmpdir/valkey" &
+get_latest_tag "quay.io/keycloak/keycloak" > "$tmpdir/keycloak" &
+get_latest_tag "quay.io/jaegertracing/jaeger" > "$tmpdir/jaeger" &
+
+wait
+
+redis_tag=$(cat "$tmpdir/redis")
+dragonfly_tag=$(cat "$tmpdir/dragonfly")
+valkey_tag=$(cat "$tmpdir/valkey")
+keycloak_tag=$(cat "$tmpdir/keycloak")
+jaeger_tag=$(cat "$tmpdir/jaeger")
+
+# Validate all tags were fetched successfully
+failed=()
+[[ -z "$redis_tag" ]] && failed+=("redis")
+[[ -z "$dragonfly_tag" ]] && failed+=("dragonfly")
+[[ -z "$valkey_tag" ]] && failed+=("valkey")
+[[ -z "$keycloak_tag" ]] && failed+=("keycloak")
+[[ -z "$jaeger_tag" ]] && failed+=("jaeger")
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "ERROR: Failed to fetch versions for: ${failed[*]}" >&2
+    exit 1
+fi
+
+# Output Helm values override YAML
+cat <<EOF
+tools:
+  jaeger:
+    image: quay.io/jaegertracing/jaeger:${jaeger_tag}
+  keycloak:
+    deployment:
+      image: quay.io/keycloak/keycloak:${keycloak_tag}
+  redis:
+    image: quay.io/opstree/redis:${redis_tag}
+  dragonfly:
+    image: docker.dragonflydb.io/dragonflydb/dragonfly:${dragonfly_tag}
+  valkey:
+    image: ghcr.io/valkey-io/valkey:${valkey_tag}
+EOF

--- a/script/get-images-versions.sh
+++ b/script/get-images-versions.sh
@@ -26,7 +26,7 @@ get_token() {
             ;;
     esac
 
-    token_response=$(curl -sf "$auth_url")
+    token_response=$(curl -sf --connect-timeout 10 --max-time 30 "$auth_url")
     echo "$token_response" | jq -r '.token // .access_token // empty'
 }
 
@@ -51,9 +51,9 @@ fetch_all_tags() {
 
     while [[ -n "$url" ]]; do
         if [[ -n "$token" ]]; then
-            response=$(curl -sSf -D - -H "Authorization: Bearer $token" "$url")
+            response=$(curl -sSf --connect-timeout 10 --max-time 30 -D - -H "Authorization: Bearer $token" "$url")
         else
-            response=$(curl -sSf -D - "$url")
+            response=$(curl -sSf --connect-timeout 10 --max-time 30 -D - "$url")
         fi
 
         headers=$(echo "$response" | sed '/^\r$/q')

--- a/script/get-images-versions.sh
+++ b/script/get-images-versions.sh
@@ -103,6 +103,8 @@ get_latest_tag() {
     echo "$latest"
 }
 
+command -v jq || { echo "'jq' is required for running this script."; exit 1; }
+
 # Fetch all tags in parallel
 tmpdir=$(mktemp -d)
 trap "rm -rf $tmpdir" EXIT

--- a/script/get-images-versions.sh
+++ b/script/get-images-versions.sh
@@ -26,7 +26,7 @@ get_token() {
             ;;
     esac
 
-    token_response=$(curl -s "$auth_url")
+    token_response=$(curl -sf "$auth_url")
     echo "$token_response" | jq -r '.token // .access_token // empty'
 }
 
@@ -51,9 +51,9 @@ fetch_all_tags() {
 
     while [[ -n "$url" ]]; do
         if [[ -n "$token" ]]; then
-            response=$(curl -sS -D - -H "Authorization: Bearer $token" "$url")
+            response=$(curl -sSf -D - -H "Authorization: Bearer $token" "$url")
         else
-            response=$(curl -sS -D - "$url")
+            response=$(curl -sSf -D - "$url")
         fi
 
         headers=$(echo "$response" | sed '/^\r$/q')
@@ -62,7 +62,7 @@ fetch_all_tags() {
         tags=$(echo "$body" | jq -r '.tags[]' 2>/dev/null || true)
         all_tags="${all_tags}"$'\n'"${tags}"
 
-        next_link=$(echo "$headers" | grep -i '^link:' | sed 's/.*<\([^>]*\)>; rel="next".*/\1/' || true)
+        next_link=$(echo "$headers" | grep -i '^link:' | grep -oP '(?<=<)[^>]+(?=>; rel="next")' || true)
         if [[ -n "$next_link" ]]; then
             if [[ "$next_link" =~ ^https?:// ]]; then
                 url="$next_link"

--- a/script/get-images-versions.sh
+++ b/script/get-images-versions.sh
@@ -62,7 +62,7 @@ fetch_all_tags() {
         tags=$(echo "$body" | jq -r '.tags[]' 2>/dev/null || true)
         all_tags="${all_tags}"$'\n'"${tags}"
 
-        next_link=$(echo "$headers" | grep -i '^link:' | grep -oP '(?<=<)[^>]+(?=>; rel="next")' || true)
+        next_link=$(echo "$headers" | grep -i '^link:' | sed 's/.*<\([^>]*\)>; rel="next".*/\1/' || true)
         if [[ -n "$next_link" ]]; then
             if [[ "$next_link" =~ ^https?:// ]]; then
                 url="$next_link"

--- a/script/get-operator-versions.sh
+++ b/script/get-operator-versions.sh
@@ -12,7 +12,7 @@ tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
 # Filter only relevant channels and bundles from the catalog.
-opm render "$CATALOG_IMAGE" 2>/dev/null | jq -c '
+opm render "$CATALOG_IMAGE" | jq -c '
   select(
     (.schema == "olm.channel" and (
       (.package == "openshift-cert-manager-operator" and .name == "stable-v1") or
@@ -21,12 +21,7 @@ opm render "$CATALOG_IMAGE" 2>/dev/null | jq -c '
     )) or
     (.schema == "olm.bundle" and .package == "servicemeshoperator3")
   )
-' > "$tmpdir/catalog.jsonl"
-
-if [[ ! -s "$tmpdir/catalog.jsonl" ]]; then
-    echo "ERROR: Failed to render or filter catalog ${CATALOG_IMAGE}" >&2
-    exit 1
-fi
+' > "$tmpdir/catalog.jsonl" || { echo "ERROR: Failed to render or filter catalog ${CATALOG_IMAGE}" >&2; exit 1; }
 
 # Sort and select latest versions of operators and their dependencies from the catalog outputting as JSON object.
 # Specific channels are used for each operator

--- a/script/get-operator-versions.sh
+++ b/script/get-operator-versions.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 
 CATALOG_IMAGE="${CATALOG_IMAGE:-registry.redhat.io/redhat/redhat-operator-index:v4.22}"
 
+command -v jq || { echo "'jq' is required for running this script."; exit 1; }
+command -v opm || { echo "'opm' is required for running this script."; exit 1; }
+
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 

--- a/script/get-operator-versions.sh
+++ b/script/get-operator-versions.sh
@@ -1,98 +1,101 @@
 #!/bin/bash
-# Requires jq
-# Script queries newest version of operator from catlaog.redhat.com and outputs frozen versions
-# Picks newest version as a version number which is semantically biggest
+# Requires jq and opm
+# Requires podman to be authenticated to registry.redhat.io
+# Resolves newest operator CSV versions from the Red Hat operator index catalog specified in env CATALOG_IMAGE,
+# Picks biggest semantically version as latest
 
 set -euo pipefail
 
-API_BASE="https://catalog.redhat.com/api/containers/v1/images"
+CATALOG_IMAGE="${CATALOG_IMAGE:-registry.redhat.io/redhat/redhat-operator-index:v4.22}"
 
-get_latest_version() {
-    local repo="$1"
-    local keep_suffix="${2:-false}"
-    local response version
-
-    response=$(curl -s "${API_BASE}?page_size=10&filter=repositories.repository==${repo}&sort_by=creation_date%5Bdesc%5D")
-
-    if [[ "$keep_suffix" == "true" ]]; then
-        # For keycloak: sort by both version and suffix number
-        version=$(echo "$response" | jq -r '
-            [.data[].repositories[]
-             | select(.repository == "'"$repo"'")
-             | .tags[].name
-             | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+$"))]
-            | unique
-            | sort_by(split("-") | [(.[0] | split(".") | map(tonumber)), (.[1] | tonumber)])
-            | last // empty
-        ')
-    else
-        version=$(echo "$response" | jq -r '
-            [.data[].repositories[]
-             | select(.repository == "'"$repo"'")
-             | .tags[].name
-             | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]{1,2})?$"))]
-            | unique
-            | sort_by(split("-")[0] | ltrimstr("v") | split(".") | map(tonumber))
-            | last // empty
-        ')
-    fi
-
-    if [[ -z "$version" ]]; then
-        return
-    fi
-
-    [[ "$version" != v* ]] && version="v${version}"
-    echo "$version"
-}
-
-# Fetch all versions in parallel
 tmpdir=$(mktemp -d)
-trap "rm -rf $tmpdir" EXIT
+trap 'rm -rf "$tmpdir"' EXIT
 
-get_latest_version "cert-manager/cert-manager-operator-bundle" > "$tmpdir/cert-manager" &
-get_latest_version "rhbk/keycloak-operator-bundle" "true" > "$tmpdir/keycloak" &
-get_latest_version "openshift-service-mesh/istio-sail-operator-bundle" > "$tmpdir/istio-operator" &
-get_latest_version "openshift-service-mesh/istio-pilot-rhel9" > "$tmpdir/istio-version" &
+# Filter only relevant channels and bundles from the catalog.
+opm render "$CATALOG_IMAGE" 2>/dev/null | jq -c '
+  select(
+    (.schema == "olm.channel" and (
+      (.package == "openshift-cert-manager-operator" and .name == "stable-v1") or
+      (.package == "rhbk-operator" and (.name | test("^stable-v[0-9]+$"))) or
+      (.package == "servicemeshoperator3" and .name == "stable")
+    )) or
+    (.schema == "olm.bundle" and .package == "servicemeshoperator3")
+  )
+' > "$tmpdir/catalog.jsonl"
 
-wait
-
-cert_manager_version=$(cat "$tmpdir/cert-manager")
-keycloak_full_version=$(cat "$tmpdir/keycloak")
-istio_operator_version=$(cat "$tmpdir/istio-operator")
-istio_version=$(cat "$tmpdir/istio-version")
-
-# Validate all versions were fetched successfully
-failed=()
-[[ -z "$cert_manager_version" ]] && failed+=("cert-manager")
-[[ -z "$keycloak_full_version" ]] && failed+=("keycloak")
-[[ -z "$istio_operator_version" ]] && failed+=("istio-operator")
-[[ -z "$istio_version" ]] && failed+=("istio-version")
-
-if [[ ${#failed[@]} -gt 0 ]]; then
-    echo "ERROR: Failed to fetch versions for: ${failed[*]}" >&2
+if [[ ! -s "$tmpdir/catalog.jsonl" ]]; then
+    echo "ERROR: Failed to render or filter catalog ${CATALOG_IMAGE}" >&2
     exit 1
 fi
 
-# Transform keycloak version: v26.4.11-2 -> base=v26.4.11, suffix=2
-keycloak_version="${keycloak_full_version%%-*}"
-keycloak_suffix="${keycloak_full_version##*-}"
+# Sort and select latest versions of operators and their dependencies from the catalog outputting as JSON object.
+# Specific channels are used for each operator
+result=$(jq -s -c '
+  def semver_tuple($v):
+    ($v | ltrimstr("v") | split(".") | map(tonumber));
 
-# Output Helm values override YAML
+  def csv_semver_key($csv):
+    ($csv | capture("\\.v(?<ver>[0-9]+\\.[0-9]+\\.[0-9]+)") | .ver) as $ver | semver_tuple($ver);
+
+  def keycloak_key($csv):
+    ($csv | capture("\\.v(?<base>[0-9]+\\.[0-9]+\\.[0-9]+)-opr\\.(?<suffix>[0-9]+)") |
+      (.base | split(".") | map(tonumber)) + [(.suffix | tonumber)]);
+
+  def istiod_version($name):
+    ($name | capture("^images_v(?<maj>[0-9]+)_(?<min>[0-9]+)_(?<pat>[0-9]+)_istiod$") |
+      "v\(.maj).\(.min).\(.pat)");
+
+  . as $objects
+  | [$objects[] | select(.schema == "olm.channel" and .package == "openshift-cert-manager-operator" and .name == "stable-v1") | .entries[].name] as $cert_csvs
+  | [$objects[] | select(.schema == "olm.channel" and .package == "rhbk-operator" and (.name | test("^stable-v[0-9]+$"))) | .entries[].name] as $keycloak_csvs
+  | [$objects[] | select(.schema == "olm.channel" and .package == "servicemeshoperator3" and .name == "stable") | .entries[].name] as $istio_csvs
+  | ($cert_csvs | unique | sort_by(csv_semver_key(.)) | last) as $cert_csv
+  | ($keycloak_csvs | unique | sort_by(keycloak_key(.)) | last) as $keycloak_csv
+  | ($istio_csvs | unique | sort_by(csv_semver_key(.)) | last) as $istio_csv
+  | [$objects[] | select(.schema == "olm.bundle" and .name == $istio_csv) | .relatedImages[]?.name | select(test("_istiod$")) | istiod_version(.)] as $istio_versions
+  | ($istio_versions | unique | sort_by(. as $v | semver_tuple($v)) | last) as $istio_version
+  | ($keycloak_csv | if . then capture("\\.v(?<ver>[0-9]+\\.[0-9]+\\.[0-9]+)-opr\\.(?<suffix>[0-9]+)") else null end) as $keycloak_parts
+  | {
+      cert_csv: $cert_csv,
+      keycloak_csv: $keycloak_csv,
+      keycloak_major: (if $keycloak_parts then ($keycloak_parts.ver | split(".")[0]) else null end),
+      istio_csv: $istio_csv,
+      istio_version: $istio_version
+    }
+' "$tmpdir/catalog.jsonl")
+
+cert_csv=$(jq -r '.cert_csv // empty' <<< "$result")
+keycloak_csv=$(jq -r '.keycloak_csv // empty' <<< "$result")
+keycloak_major=$(jq -r '.keycloak_major // empty' <<< "$result")
+istio_csv=$(jq -r '.istio_csv // empty' <<< "$result")
+istio_version=$(jq -r '.istio_version // empty' <<< "$result")
+
+failed=()
+[[ -z "$cert_csv" ]] && failed+=("cert-manager")
+[[ -z "$keycloak_csv" ]] && failed+=("keycloak")
+[[ -z "$istio_csv" ]] && failed+=("servicemesh (ossm3) operator")
+[[ -z "$istio_version" ]] && failed+=("istio version")
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "ERROR: Failed to resolve versions for: ${failed[*]}" >&2
+    exit 1
+fi
+
 cat <<EOF
 certManager:
   operator:
-    startingCSV: cert-manager-operator.${cert_manager_version}
+    startingCSV: ${cert_csv}
     installPlanApproval: Manual
 tools:
   keycloak:
     operator:
-      channel: stable-${keycloak_version%%.*}
-      startingCSV: rhbk-operator.${keycloak_version}-opr.${keycloak_suffix}
+      channel: stable-v${keycloak_major}
+      startingCSV: ${keycloak_csv}
       installPlanApproval: Manual
 istio:
   ossm3:
     operator:
-      startingCSV: servicemeshoperator3.${istio_operator_version}
+      startingCSV: ${istio_csv}
       installPlanApproval: Manual
     version: ${istio_version}
 EOF

--- a/script/get-operator-versions.sh
+++ b/script/get-operator-versions.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Requires jq
+# Script queries newest version of operator from catlaog.redhat.com and outputs frozen versions
+# Picks newest version as a version number which is semantically biggest
+
+set -euo pipefail
+
+API_BASE="https://catalog.redhat.com/api/containers/v1/images"
+
+get_latest_version() {
+    local repo="$1"
+    local keep_suffix="${2:-false}"
+    local response version
+
+    response=$(curl -s "${API_BASE}?page_size=10&filter=repositories.repository==${repo}&sort_by=creation_date%5Bdesc%5D")
+
+    if [[ "$keep_suffix" == "true" ]]; then
+        # For keycloak: sort by both version and suffix number
+        version=$(echo "$response" | jq -r '
+            [.data[].repositories[]
+             | select(.repository == "'"$repo"'")
+             | .tags[].name
+             | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+$"))]
+            | unique
+            | sort_by(split("-") | [(.[0] | split(".") | map(tonumber)), (.[1] | tonumber)])
+            | last // empty
+        ')
+    else
+        version=$(echo "$response" | jq -r '
+            [.data[].repositories[]
+             | select(.repository == "'"$repo"'")
+             | .tags[].name
+             | select(test("^v?[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9]{1,2})?$"))]
+            | unique
+            | sort_by(split("-")[0] | ltrimstr("v") | split(".") | map(tonumber))
+            | last // empty
+        ')
+    fi
+
+    if [[ -z "$version" ]]; then
+        return
+    fi
+
+    [[ "$version" != v* ]] && version="v${version}"
+    echo "$version"
+}
+
+# Fetch all versions in parallel
+tmpdir=$(mktemp -d)
+trap "rm -rf $tmpdir" EXIT
+
+get_latest_version "cert-manager/cert-manager-operator-bundle" > "$tmpdir/cert-manager" &
+get_latest_version "rhbk/keycloak-operator-bundle" "true" > "$tmpdir/keycloak" &
+get_latest_version "openshift-service-mesh/istio-sail-operator-bundle" > "$tmpdir/istio-operator" &
+get_latest_version "openshift-service-mesh/istio-pilot-rhel9" > "$tmpdir/istio-version" &
+
+wait
+
+cert_manager_version=$(cat "$tmpdir/cert-manager")
+keycloak_full_version=$(cat "$tmpdir/keycloak")
+istio_operator_version=$(cat "$tmpdir/istio-operator")
+istio_version=$(cat "$tmpdir/istio-version")
+
+# Validate all versions were fetched successfully
+failed=()
+[[ -z "$cert_manager_version" ]] && failed+=("cert-manager")
+[[ -z "$keycloak_full_version" ]] && failed+=("keycloak")
+[[ -z "$istio_operator_version" ]] && failed+=("istio-operator")
+[[ -z "$istio_version" ]] && failed+=("istio-version")
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+    echo "ERROR: Failed to fetch versions for: ${failed[*]}" >&2
+    exit 1
+fi
+
+# Transform keycloak version: v26.4.11-2 -> base=v26.4.11, suffix=2
+keycloak_version="${keycloak_full_version%%-*}"
+keycloak_suffix="${keycloak_full_version##*-}"
+
+# Output Helm values override YAML
+cat <<EOF
+certManager:
+  operator:
+    startingCSV: cert-manager-operator.${cert_manager_version}
+    installPlanApproval: Manual
+tools:
+  keycloak:
+    operator:
+      channel: stable-${keycloak_version%%.*}
+      startingCSV: rhbk-operator.${keycloak_version}-opr.${keycloak_suffix}
+      installPlanApproval: Manual
+istio:
+  ossm3:
+    operator:
+      startingCSV: servicemeshoperator3.${istio_operator_version}
+      installPlanApproval: Manual
+    version: ${istio_version}
+EOF


### PR DESCRIPTION
Closes #80 
Adds scripts which gather newest versions of dependancy operators and tools images. 

Full list images:
- quay.io/opstree/redis
- docker.dragonflydb.io/dragonflydb/dragonfly
- ghcr.io/valkey-io/valkey
- quay.io/keycloak/keycloak
- quay.io/jaegertracing/jaeger

Full list operators:
- cert-manager/cert-manager-operator-bundle
- rhbk/keycloak-operator-bundle
- openshift-service-mesh/istio-sail-operator-bundle
- openshift-service-mesh/istio-pilot-rhel9

After this PR a change in testsuite-pipelines is needed to allow for versioned deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional “freeze versions” mode that auto-detects and pins container image tags and operator CSV versions for reproducible installs.
  * Automatically generates a Helm values override from the resolved image and operator versions, merging the results into a single output.
* **Bug Fixes**
  * Improved reliability by using strict script safety, running lookups in parallel, and failing fast with clear errors if any required version can’t be determined.
* **Chores**
  * Added version-detection scripts and updated tool Helm installs to use tool-specific additional flags, preserving the existing timeout behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->