### PR TITLE
feat: add extension image parameter to overwrite initContainer's image of kuadrant-operator at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 additionalManifests.yaml
+extensionsManifests.yaml
 .idea
 
 # macOS system files

--- a/charts/kuadrant-operators/templates/kuadrant/02a-extensionsManifests.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/02a-extensionsManifests.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.kuadrant.extensionsImage }}
+{{- range .Values.extensionsManifests }}
+---
+{{ tpl (. | toYaml) $ }}
+{{- end }}
+{{- end }}

--- a/charts/kuadrant-operators/templates/kuadrant/08-extensions-patch.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/08-extensions-patch.yaml
@@ -74,7 +74,7 @@ data:
     # Wait for the CSV to be installed via the subscription
     echo "Waiting for CSV to be installed..."
     for i in $(seq 1 60); do
-        CSV=$(kubectl get subscription kuadrant-operator -o=jsonpath='{.status.installedCSV}' 2>/dev/null)
+        CSV=$(kubectl get subscription {{ .Values.kuadrant.operatorName }} -o=jsonpath='{.status.installedCSV}' 2>/dev/null)
         if [ -n "$CSV" ]; then
             break
         fi
@@ -134,9 +134,8 @@ data:
       },
       {
         "op": "add",
-        "path": "/spec/install/spec/deployments/$DEP_IDX/spec/template/spec/initContainers",
-        "value": [
-          {
+        "path": "/spec/install/spec/deployments/$DEP_IDX/spec/template/spec/initContainers/-",
+        "value": {
             "name": "copy-extensions",
             "command": ["cp", "-r", "/extensions/.", "/export"],
             "image": "$EXTENSIONS_IMAGE",
@@ -148,7 +147,6 @@ data:
               }
             ]
           }
-        ]
       }
     ]
     PATCH_EOF

--- a/charts/kuadrant-operators/templates/kuadrant/08-extensions-patch.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/08-extensions-patch.yaml
@@ -1,0 +1,189 @@
+{{- if .Values.kuadrant.extensionsImage }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: extensions-patch-hook
+  namespace: {{ .Values.kuadrant.namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: extensions-patch-hook-role
+  namespace: {{ .Values.kuadrant.namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - clusterserviceversions
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: extensions-patch-hook-rb
+  namespace: {{ .Values.kuadrant.namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extensions-patch-hook-role
+subjects:
+- kind: ServiceAccount
+  name: extensions-patch-hook
+  namespace: {{ .Values.kuadrant.namespace }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: extensions-patch-hook
+  namespace: {{ .Values.kuadrant.namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  "run.sh": |
+    #!/bin/bash
+    set -xe
+
+    EXTENSIONS_IMAGE="{{ .Values.kuadrant.extensionsImage }}"
+
+    # Wait for the CSV to be installed via the subscription
+    echo "Waiting for CSV to be installed..."
+    for i in $(seq 1 60); do
+        CSV=$(kubectl get subscription kuadrant-operator -o=jsonpath='{.status.installedCSV}' 2>/dev/null)
+        if [ -n "$CSV" ]; then
+            break
+        fi
+        echo "Attempt $i: CSV not yet available, waiting..."
+        sleep 5
+    done
+
+    if [ -z "$CSV" ]; then
+        echo "ERROR: Timed out waiting for CSV"
+        exit 1
+    fi
+
+    echo "Found CSV: $CSV"
+
+    # Wait for CSV to reach Succeeded phase
+    kubectl wait --for=jsonpath='{.status.phase}'=Succeeded csv/"$CSV" --timeout=120s
+
+    # Find the deployment index for kuadrant-operator-controller-manager
+    DEP_IDX=$(kubectl get csv "$CSV" -o json | jq '[.spec.install.spec.deployments[]] | to_entries[] | select(.value.name == "kuadrant-operator-controller-manager") | .key')
+
+    if [ -z "$DEP_IDX" ]; then
+        echo "ERROR: Could not find kuadrant-operator-controller-manager deployment in CSV"
+        exit 1
+    fi
+
+    # Find the manager container index
+    MGR_IDX=$(kubectl get csv "$CSV" -o json | jq ".spec.install.spec.deployments[$DEP_IDX].spec.template.spec.containers | to_entries[] | select(.value.name == \"manager\") | .key")
+
+    if [ -z "$MGR_IDX" ]; then
+        echo "ERROR: Could not find manager container in CSV deployment"
+        exit 1
+    fi
+
+    echo "Patching CSV: deployment index=$DEP_IDX, manager container index=$MGR_IDX"
+
+    # Build the JSON patch:
+    # 1. Add the extensions emptyDir volume
+    # 2. Add volumeMount to the manager container
+    # 3. Add the copy-extensions initContainer
+    PATCH=$(cat <<PATCH_EOF
+    [
+      {
+        "op": "add",
+        "path": "/spec/install/spec/deployments/$DEP_IDX/spec/template/spec/volumes/-",
+        "value": {
+          "name": "extensions-binary-volume",
+          "emptyDir": {}
+        }
+      },
+      {
+        "op": "add",
+        "path": "/spec/install/spec/deployments/$DEP_IDX/spec/template/spec/containers/$MGR_IDX/volumeMounts/-",
+        "value": {
+          "mountPath": "/extensions",
+          "name": "extensions-binary-volume"
+        }
+      },
+      {
+        "op": "add",
+        "path": "/spec/install/spec/deployments/$DEP_IDX/spec/template/spec/initContainers",
+        "value": [
+          {
+            "name": "copy-extensions",
+            "command": ["cp", "-r", "/extensions/.", "/export"],
+            "image": "$EXTENSIONS_IMAGE",
+            "imagePullPolicy": "IfNotPresent",
+            "volumeMounts": [
+              {
+                "mountPath": "/export",
+                "name": "extensions-binary-volume"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+    PATCH_EOF
+    )
+
+    kubectl patch csv "$CSV" --type json -p "$PATCH"
+    echo "CSV patched successfully with extensions image: $EXTENSIONS_IMAGE"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: extensions-patch-hook
+  namespace: {{ .Values.kuadrant.namespace }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      containers:
+      - command:
+        - /bin/bash
+        - /scripts/run.sh
+        image: quay.io/kuadrant/testsuite-pipelines-tools:latest
+        name: extensions-patch
+        volumeMounts:
+        - name: script-volume
+          mountPath: /scripts
+        resources: {}
+      volumes:
+        - name: script-volume
+          configMap:
+            name: extensions-patch-hook
+      serviceAccount: extensions-patch-hook
+      restartPolicy: OnFailure
+{{- end }}

--- a/example-extensionsManifests.yaml
+++ b/example-extensionsManifests.yaml
@@ -61,7 +61,9 @@ extensionsManifests:
                   request:
                     items:
                       properties:
-                        intention:
+                        headersToAdd:
+                          type: string
+                        logMessage:
                           type: string
                         method:
                           type: string
@@ -69,11 +71,19 @@ extensionsManifests:
                           type: string
                         type:
                           enum:
-                          - allow
                           - grpc_method
+                          - deny
+                          - fail
+                          - add_headers
                           type: string
                         var:
                           type: string
+                        withBody:
+                          type: string
+                        withHeaders:
+                          type: string
+                        withStatus:
+                          type: integer
                       required:
                       - type
                       type: object
@@ -83,15 +93,27 @@ extensionsManifests:
                       properties:
                         headersToAdd:
                           type: string
+                        logMessage:
+                          type: string
+                        method:
+                          type: string
                         predicate:
                           type: string
-                        responseCode:
-                          type: integer
                         type:
                           enum:
+                          - grpc_method
+                          - deny
+                          - fail
                           - add_headers
-                          - with_response_code
                           type: string
+                        var:
+                          type: string
+                        withBody:
+                          type: string
+                        withHeaders:
+                          type: string
+                        withStatus:
+                          type: integer
                       required:
                       - type
                       type: object

--- a/example-extensionsManifests.yaml
+++ b/example-extensionsManifests.yaml
@@ -1,0 +1,268 @@
+extensionsManifests:
+  - apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      annotations:
+        controller-gen.kubebuilder.io/version: v0.19.0
+      name: pipelinepolicies.extensions.kuadrant.io
+    spec:
+      group: extensions.kuadrant.io
+      names:
+        kind: PipelinePolicy
+        listKind: PipelinePolicyList
+        plural: pipelinepolicies
+        singular: pipelinepolicy
+      scope: Namespaced
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              apiVersion:
+                description: |-
+                  APIVersion defines the versioned schema of this representation of an object.
+                  Servers should convert recognized schemas to the latest internal value, and
+                  may reject unrecognized values.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                type: string
+              kind:
+                description: |-
+                  Kind is a string value representing the REST resource this object represents.
+                  Servers may infer this from the endpoint the client submits requests to.
+                  Cannot be updated.
+                  In CamelCase.
+                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                type: string
+              metadata:
+                type: object
+              spec:
+                properties:
+                  actionMethods:
+                    items:
+                      properties:
+                        messageTemplate:
+                          type: string
+                        method:
+                          type: string
+                        name:
+                          type: string
+                        service:
+                          type: string
+                        url:
+                          type: string
+                      required:
+                      - messageTemplate
+                      - method
+                      - name
+                      - service
+                      - url
+                      type: object
+                    type: array
+                  request:
+                    items:
+                      properties:
+                        intention:
+                          type: string
+                        method:
+                          type: string
+                        predicate:
+                          type: string
+                        type:
+                          enum:
+                          - allow
+                          - grpc_method
+                          type: string
+                        var:
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    type: array
+                  response:
+                    items:
+                      properties:
+                        headersToAdd:
+                          type: string
+                        predicate:
+                          type: string
+                        responseCode:
+                          type: integer
+                        type:
+                          enum:
+                          - add_headers
+                          - with_response_code
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    type: array
+                  targetRef:
+                    description: |-
+                      LocalPolicyTargetReferenceWithSectionName identifies an API object to apply a
+                      direct policy to. This should be used as part of Policy resources that can
+                      target single resources. For more information on how this policy attachment
+                      mode works, and a sample Policy resource, refer to the policy attachment
+                      documentation for Gateway API.
+
+                      Note: This should only be used for direct policy attachment when references
+                      to SectionName are actually needed. In all other cases,
+                      LocalPolicyTargetReference should be used.
+                    properties:
+                      group:
+                        description: Group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      sectionName:
+                        description: |-
+                          SectionName is the name of a section within the target resource. When
+                          unspecified, this targetRef targets the entire resource. In the following
+                          resources, SectionName is interpreted as the following:
+
+                          * Gateway: Listener name
+                          * HTTPRoute: HTTPRouteRule name
+                          * Service: Port name
+
+                          If a SectionName is specified, but does not exist on the targeted object,
+                          the Policy must fail to attach, and the policy implementation should record
+                          a `ResolvedRefs` or similar Condition in the Policy's status.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                    - group
+                    - kind
+                    - name
+                    type: object
+                    x-kubernetes-validations:
+                    - message: Invalid targetRef.group. The only supported value is 'gateway.networking.k8s.io'
+                      rule: self.group == 'gateway.networking.k8s.io'
+                    - message: Invalid targetRef.kind. The only supported values are 'HTTPRoute'
+                        and 'Gateway'
+                      rule: self.kind == 'HTTPRoute' || self.kind == 'Gateway'
+                required:
+                - targetRef
+                type: object
+              status:
+                properties:
+                  conditions:
+                    items:
+                      description: Condition contains details for one aspect of the current
+                        state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False, Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  observedGeneration:
+                    format: int64
+                    type: integer
+                type: object
+            type: object
+        served: true
+        storage: true
+        subresources:
+          status: {}
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: pipeline-policy-manager-role
+    rules:
+    - apiGroups:
+      - extensions.kuadrant.io
+      resources:
+      - pipelinepolicies
+      verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    - apiGroups:
+      - extensions.kuadrant.io
+      resources:
+      - pipelinepolicies/finalizers
+      verbs:
+      - update
+    - apiGroups:
+      - extensions.kuadrant.io
+      resources:
+      - pipelinepolicies/status
+      verbs:
+      - get
+      - patch
+      - update
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: pipeline-policy-manager-rolebinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: pipeline-policy-manager-role
+    subjects:
+    - kind: ServiceAccount
+      name: kuadrant-operator-controller-manager
+      namespace: kuadrant-system

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@ for arg in "$@"; do
             additional_flags+=" --values additionalManifests.yaml --set tools.enabled=true"
             ;;
         -e)
+            echo "Including extensions manifests"
             additional_flags+=" --values extensionsManifests.yaml"
             ;;
     esac

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,16 @@ cd "$(dirname "$0")"
 
 additional_flags=''
 
-if [[ "$1" == "-t" ]]; then
-    additional_flags+=" --values additionalManifests.yaml --set tools.enabled=true"
-fi
+for arg in "$@"; do
+    case "$arg" in
+        -t)
+            additional_flags+=" --values additionalManifests.yaml --set tools.enabled=true"
+            ;;
+        -e)
+            additional_flags+=" --values extensionsManifests.yaml"
+            ;;
+    esac
+done
 
 if [[ "$INSTALL_RHCL_GA" == "true" ]]; then
     additional_flags+=" --set kuadrant.indexImage='' --set kuadrant.operatorName=rhcl-operator --set kuadrant.channel=stable"
@@ -23,7 +30,7 @@ echo "--Installing instances---"
 helm_cmd="helm install $additional_flags --wait kuadrant-instances charts/kuadrant-instances"
 eval "$helm_cmd"
 
-if [[ "$1" == "-t" ]]; then
+if [[ " $* " == *" -t "* ]]; then
 echo "--Installing tools operators"
 helm install --wait tools-operators charts/tools-operators
 

--- a/values.yaml
+++ b/values.yaml
@@ -57,6 +57,13 @@ kuadrant:
   wasmPluginImage: ""
   protectedRegistry: ""
 
+  # (optional)
+  # Extensions image to patch into the operator CSV as an initContainer.
+  # The initContainer copies extension binaries from /extensions/ to a shared volume
+  # mounted at /extensions in the manager container.
+  # Example: quay.io/kuadrant/internal-extensions:latest
+  extensionsImage: ""
+
   # Enable observability (debug logging, tracing, monitoring) for Kuadrant and its components
   # When enabled, this will:
   # - Set LOG_LEVEL=debug for Kuadrant operator
@@ -78,7 +85,7 @@ istio:
   # 'ossm3' for Openshift Service mesh v3 (recommended for every Openshift versions)
   # 'ocp' for installing Istio managed by Gateway API (not recommended: mTLS is not supported)
   # if left empty no Gateway API implementation is installed
-  istioProvider: ossm3
+  istioProvider: ocp
   ossm3:  # Openshift Service Mesh, but version 3
     version: v1.28-latest
     operator:

--- a/values.yaml
+++ b/values.yaml
@@ -62,7 +62,7 @@ kuadrant:
   # The initContainer copies extension binaries from /extensions/ to a shared volume
   # mounted at /extensions in the manager container.
   # Example: quay.io/kuadrant/internal-extensions:latest
-  extensionsImage: ""
+  extensionsImage: "quay.io/kuadrant/internal-extensions:latest"
 
   # Enable observability (debug logging, tracing, monitoring) for Kuadrant and its components
   # When enabled, this will:

--- a/values.yaml
+++ b/values.yaml
@@ -85,7 +85,7 @@ istio:
   # 'ossm3' for Openshift Service mesh v3 (recommended for every Openshift versions)
   # 'ocp' for installing Istio managed by Gateway API (not recommended: mTLS is not supported)
   # if left empty no Gateway API implementation is installed
-  istioProvider: ocp
+  istioProvider: ossm3
   ossm3:  # Openshift Service Mesh, but version 3
     version: v1.28-latest
     operator:


### PR DESCRIPTION
The idea is to deploy a custom image for the extensions that are being copied at startup time by the `kuadrant-operator`. This can't be achieved straightforwardly without modifying the csv which replaces the i`nitContainer`'s image in favor of the one provided from the `values.yaml`. There is another catch though, your custom extension won't probably work without the necessary rbac and the crds, hence the introduction of another values file, i.e extensions-manifest. Easiest way to test would be to use the example manifest, add `quay.io/acristur/internal-extensions:latest` (will move the repository later under kuadrant) and run `./install.sh -t -e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional extensionsImage to enable loading custom extensions into the operator.
  * Automatic extension installation during operator deploy via a post-install/post-upgrade job.
  * Introduce PipelinePolicy CRD to define pipeline-based request/response policies.

* **Configuration Changes**
  * New values key: kuadrant.extensionsImage (default "").

* **Improvements**
  * Installer script accepts flags from any argument position for more flexible CLI usage.
  * extensionsManifests.yaml added to .gitignore.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/helm-charts-olm/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->