### PR TITLE
Fix extensions post-install hook patch for initContainers

### DIFF
--- a/charts/kuadrant-operators/templates/kuadrant/08-extensions-patch.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/08-extensions-patch.yaml
@@ -134,8 +134,9 @@ data:
       },
       {
         "op": "add",
-        "path": "/spec/install/spec/deployments/$DEP_IDX/spec/template/spec/initContainers/-",
-        "value": {
+        "path": "/spec/install/spec/deployments/$DEP_IDX/spec/template/spec/initContainers",
+        "value": [
+          {
             "name": "copy-extensions",
             "command": ["cp", "-r", "/extensions/.", "/export"],
             "image": "$EXTENSIONS_IMAGE",
@@ -147,6 +148,7 @@ data:
               }
             ]
           }
+        ]
       }
     ]
     PATCH_EOF


### PR DESCRIPTION
## Summary
- The extensions post-install hook uses a JSON patch to add an `initContainers` entry to the CSV deployment spec
- The patch used `initContainers/-` which attempts to append to an existing array, but the CSV deployment has no `initContainers` field at all
- Changed the patch to use `initContainers` (without `/-`) and set the value to an array, so it creates the field rather than trying to append to a non-existent one

## Test plan
- [ ] Deploy with `kuadrant.extensionsImage` set and verify the post-install hook job succeeds
- [ ] Verify the CSV is patched correctly with the initContainer and volume