### PR TITLE
quick fix hardcoded subscription name

### DIFF
--- a/charts/kuadrant-operators/templates/kuadrant/08-extensions-patch.yaml
+++ b/charts/kuadrant-operators/templates/kuadrant/08-extensions-patch.yaml
@@ -74,7 +74,7 @@ data:
     # Wait for the CSV to be installed via the subscription
     echo "Waiting for CSV to be installed..."
     for i in $(seq 1 60); do
-        CSV=$(kubectl get subscription {{ .Values.kuadrant.operatorName }} -o=jsonpath='{.status.installedCSV}' 2>/dev/null)
+        CSV=$(kubectl get subscription kuadrant-operator -o=jsonpath='{.status.installedCSV}' 2>/dev/null)
         if [ -n "$CSV" ]; then
             break
         fi


### PR DESCRIPTION
The subscription name is hardcoded (https://github.com/Kuadrant/helm-charts-olm/blob/main/charts/kuadrant-operators/templates/kuadrant/06-subscription.yaml), so installation of rhcl-operator or authorino-operator will fail. (authorino-operator will probably fail too, but this can be mitigated by having extensions image empty in values)

In any case I hope this is a temporary job and will be replaced by configMap definition or some other more userfriendly way to deploy extensions to Kuadrant than by patching csv which is not durable across upgrades or subscription edits..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator installation and upgrade hook configuration to improve deployment consistency across environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/helm-charts-olm/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->