### PR TITLE
feat: enable wasm debug logging for gateway by default

### DIFF
--- a/charts/kuadrant-instances/templates/ossm3/02-istio.yaml
+++ b/charts/kuadrant-instances/templates/ossm3/02-istio.yaml
@@ -39,6 +39,9 @@ spec:
             port: 4317
             service: jaeger-collector.tools.svc.cluster.local
 {{ end }}
+    global:
+      proxy:
+        componentLogLevel: "wasm:debug"
     pilot:
       autoscaleMin: 2
   version: {{ .Values.istio.ossm3.version }}


### PR DESCRIPTION
## Summary
  - Enable wasm debug logging on gateway proxies by default for easier debugging on testing clusters

  ## Test plan
  - [ ] Deploy the chart and verify gateway proxy pods emit wasm debug logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Istio proxy configuration in OSSM3 template with additional component logging settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/helm-charts-olm/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->