### PR TITLE
fix: Remove uneeded KC_PROXY_HEADERS and small fixes

### DIFF
--- a/charts/tools-instances/templates/keycloak/deployment/01-deployment.yaml
+++ b/charts/tools-instances/templates/keycloak/deployment/01-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: keycloak
           image: {{ .Values.tools.keycloak.deployment.image }}
+          imagePullPolicy: Always
           args:
             - start-dev
             - --health-enabled=true
@@ -42,8 +43,6 @@ spec:
                   key: password
             - name: KC_HTTP_ENABLED
               value: "true"
-            - name: KC_PROXY_HEADERS
-              value: "xforwarded"
             - name: KC_DB
               value: "postgres"
             - name: "KC_DB_URL"

--- a/values-tools.yaml
+++ b/values-tools.yaml
@@ -16,7 +16,7 @@ tools:
       startingCSV: rhbk-operator.v26.0.10-opr.1  # Ignored if 'Automatic' bellow
       installPlanApproval: Automatic  # can be 'Automatic' or 'Manual'
     deployment:
-      image: quay.io/keycloak/keycloak:26.4
+      image: quay.io/keycloak/keycloak:26.6
     database:
       image: quay.io/sclorg/postgresql-16-c10s:latest
   redis:


### PR DESCRIPTION
When mtls is enabled in Kuadrant, Authorino cant connect to Keycloak. I noticed removing this env var fixes the issue. Not sure what was the original use for it. All tests pass except tracing ones which needs more investigation. Deployment is not the default keycloak installation anyways.

At this occasion I also did small refactors and version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Keycloak updated from version 26.4 to 26.6.
  * Deployment configuration updated for improved image consistency and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->