### PR TITLE
Add developer portal config

### DIFF
--- a/charts/kuadrant-instances/templates/kuadrant/01-kuadrant.yaml
+++ b/charts/kuadrant-instances/templates/kuadrant/01-kuadrant.yaml
@@ -4,8 +4,8 @@ kind: Kuadrant
 metadata:
   name: kuadrant-sample
   namespace: {{ .Values.kuadrant.namespace }}
-{{ if eq .Values.kuadrant.enableObservability true }}
 spec:
+{{ if eq .Values.kuadrant.enableObservability true }}
   observability:
     dataPlane:
       defaultLevels:
@@ -15,7 +15,15 @@ spec:
     tracing:
       defaultEndpoint: 'rpc://jaeger-collector.tools.svc.cluster.local:4317'
       insecure: true
-{{ else }}
-spec: {}
+{{ end }}
+{{- $clusterVersion := (lookup "config.openshift.io/v1" "ClusterVersion" "" "version") -}}
+{{- $ocpVersionOk := false -}}
+{{- if $clusterVersion -}}
+  {{- $ocpVersionOk = semverCompare ">=4.20.0-0" $clusterVersion.status.desired.version -}}
+{{- end -}}
+{{ if and .Values.kuadrant.developerPortal (eq .Values.kuadrant.developerPortal.enabled true) $ocpVersionOk }}
+  components:
+    developerPortal:
+      enabled: true
 {{ end }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -73,6 +73,12 @@ kuadrant:
   # - Enable observability features
   enableObservability: true
 
+  # Enable the developer portal component
+  # When enabled, activates the developer portal controller for APIProduct and APIKeyRequest resources
+  # Note: Requires OpenShift 4.20+
+  developerPortal:
+    enabled: true
+
 # Installs Gateway API CRD's on cluster. Not needed for Openshift 4.19+
 gatewayAPI:
   version: v1.5.0  # v1.3.0, v1.4.0, v1.5.0 available; leave empty for installing on Openshift 4.19+


### PR DESCRIPTION
## Summary
- Add `kuadrant.developerPortal.enabled` configuration option to `values.yaml`
- Update Kuadrant CR template to render `spec.components.developerPortal.enabled` when set
- Enables testsuite clusters to auto-enable developer portal without manual CR editing

## Changes
- `values.yaml`: Add `developerPortal.enabled: true` config under kuadrant section
- `charts/kuadrant-instances/templates/kuadrant/01-kuadrant.yaml`: Refactor to support both observability and developerPortal configs independently

Closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Developer portal component can be enabled via configuration and will be activated when platform compatibility checks pass.

* **Configuration Improvements**
  * Deployment now always includes the top-level spec block, so core settings remain present even when observability is disabled.
  * Developer portal enablement is now guarded by a compatibility check and no longer emits an empty spec fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->