### PR TITLE
Release pipeline

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -2,16 +2,16 @@ name: Helm chart static analysis
 on:
   push:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # ratchet:helm/chart-testing-action@v2.8.0
       - name: Check if linting is required
         id: list-changed
         run: |

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,134 @@
+name: Manual Helm chart release with frozen versions
+on:
+  workflow_dispatch:
+    inputs:
+      kuadrantVersion:
+        description: 'Version with optional RC suffix and product. k=kuadrant r=RHCL (example: 1.0.0-k, 2.3.4-rc1-r)'
+        required: true
+        type: string
+      indexImage:
+        description: 'Kuadrant operator index image (example: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.3)'
+        required: true
+        type: string
+      ocpVersion:
+        description: 'Openshift version to pin operator versions for. (example: v4.22)'
+        required: true
+        default: v4.22
+
+env:
+  HELM_VERSION: ${{ inputs.kuadrantVersion }}-${{ inputs.ocpVersion }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
+      - name: Validate kuadrant version format
+        run: |
+          if ! [[ "${{ inputs.kuadrantVersion }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)*-(k|r)$ ]]; then
+            echo "ERROR: Version must be in format X.Y.Z[-rcX]-(k|r) (e.g., 1.0.0-k, 2.3.4-rc1-r)"
+            exit 1
+          fi
+      - name: Validate ocp version format
+        run: |
+          if ! [[ "${{ inputs.ocpVersion }}" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Version must be in format vX.Y (e.g., v4.22)"
+            exit 1
+          fi
+
+      - name: Check tag does not already exist
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/$HELM_VERSION$"; then
+            echo "ERROR: Tag $HELM_VERSION already exists"
+            exit 1
+          fi
+
+      - name: Set up yq
+        run: sudo snap install yq
+
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # ratchet:azure/setup-helm@v5
+        with:
+          version: v3.18.4
+
+      - name: Set up opm
+        run: |
+          OPM_VERSION=$(curl -s https://api.github.com/repos/operator-framework/operator-registry/releases/latest | jq -r '.tag_name')
+          curl -Lo opm "https://github.com/operator-framework/operator-registry/releases/download/${OPM_VERSION}/linux-amd64-opm"
+          chmod +x opm
+          sudo mv opm /usr/local/bin/
+          opm version
+
+      - name: Get frozen versions
+        id: versions
+        run: |
+          export CATALOG_IMAGE="registry.redhat.io/redhat/redhat-operator-index:${{ inputs.ocpVersion }}"
+          ./script/get-all-versions.sh > frozen-versions.yaml
+          echo "Frozen versions:\n\n"
+          cat frozen-versions.yaml
+
+      - name: Merge frozen versions with values files
+        run: |
+          yq eval-all '. as $item ireduce ({}; . * $item)' values.yaml frozen-versions.yaml > values-frozen.yaml
+          yq eval-all '. as $item ireduce ({}; . * $item)' values-tools.yaml frozen-versions.yaml > values-tools-frozen.yaml
+
+          echo "Merged values.yaml:"
+          cat values-frozen.yaml
+          echo ""
+          echo "Merged values-tools.yaml:"
+          cat values-tools-frozen.yaml
+
+          mv values-frozen.yaml values.yaml
+          mv values-tools-frozen.yaml values-tools.yaml
+
+      - name: Set index image
+        run: |
+          yq -i '.kuadrant.indexImage = "${{ inputs.indexImage }}"' values.yaml
+          echo "Set indexImage to: ${{ inputs.indexImage }}"
+
+      - name: Update chart versions
+        run: |
+          for chart_dir in charts/*/; do
+            chart_file="${chart_dir}Chart.yaml"
+            if [[ -f "$chart_file" ]]; then
+              yq -i ".version = \"$HELM_VERSION\"" "$chart_file"
+              yq -i ".appVersion = \"$HELM_VERSION\"" "$chart_file"
+              echo "Updated $chart_file to version $HELM_VERSION"
+            fi
+          done
+
+      - name: Package Helm charts
+        run: |
+          mkdir .cr-release-packages
+          helm package ./charts/* -d .cr-release-packages
+
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Copy chart to gh-pages
+        run: |
+          cp .cr-release-packages/* gh-pages/
+
+      - name: Generate new index.yaml
+        run: |
+          cd gh-pages
+          helm repo index . --merge index.yaml
+
+      - name: Commit and push
+        run: |
+          cd gh-pages
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add .
+          git commit -m "Release $HELM_VERSION with frozen versions (manual release)"
+          git push origin gh-pages
+
+      - name: Create Git tag
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git tag -a "$HELM_VERSION" -m "Release $HELM_VERSION with frozen versions"
+          git push origin "$HELM_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Helm chart releases
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - 'charts/**'
       - 'values-tools.yaml'
@@ -10,15 +10,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # ratchet:actions/checkout@v7
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # ratchet:azure/setup-helm@v5
       - name: Package Helm charts
         run: |
           mkdir .cr-release-packages
           helm package ./charts/* -d .cr-release-packages
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # ratchet:actions/checkout@v3
         with:
           ref: gh-pages
           path: gh-pages

--- a/charts/kuadrant-instances/Chart.yaml
+++ b/charts/kuadrant-instances/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+appVersion: "0.0.0"
 
 # dependencies:
 # - name: kuadrant-operators

--- a/charts/kuadrant-operators/Chart.yaml
+++ b/charts/kuadrant-operators/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+appVersion: "0.0.0"

--- a/charts/tools-instances/Chart.yaml
+++ b/charts/tools-instances/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+appVersion: "0.0.0"
 
 dependencies:
   - name: vault

--- a/charts/tools-operators/Chart.yaml
+++ b/charts/tools-operators/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "1.0"
+appVersion: "0.0.0"


### PR DESCRIPTION
Closes https://github.com/Kuadrant/helm-charts-olm/issues/88
Needs #89 

Adds github action for releasing versioned charts as tags. Maybe needs release object with pre-generated text as well?

 Still work in progress - draft

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered Helm release process with version inputs and validation.
  - Releases can package charts, publish updated Helm repository metadata, and create version tags.
  - Supports releases using frozen operator versions and selected platform versions.

- **Chores**
  - Improved release and chart validation workflows by pinning action versions for more consistent execution.
  - Reset chart and application versions to `0.0.0` in preparation for a new release cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->