### PR TITLE
fix: replace database image because it is not multi-arch.

### DIFF
--- a/values-tools.yaml
+++ b/values-tools.yaml
@@ -18,7 +18,7 @@ tools:
     deployment:
       image: quay.io/keycloak/keycloak:26.6
     database:
-      image: quay.io/sclorg/postgresql-16-c10s:latest
+      image: registry.redhat.io/rhel9/postgresql-16:latest
   redis:
     enable: true
     image: quay.io/opstree/redis:latest


### PR DESCRIPTION
The current image used for the databse of keycloak is not multi-arch. There is such an image under the redhat repository in the production registry that is also multi-arch. Would advise using this instead as it is required for our arm testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database image used for Keycloak tools to a newer Red Hat PostgreSQL 16 image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->