### PR TITLE
chore: Change postgresql image to quay (again)

### DIFF
--- a/values-tools.yaml
+++ b/values-tools.yaml
@@ -18,7 +18,7 @@ tools:
     deployment:
       image: quay.io/keycloak/keycloak:26.6
     database:
-      image: registry.redhat.io/rhel9/postgresql-16:latest
+      image: quay.io/sclorg/postgresql-16-c9s:latest
   redis:
     enable: true
     image: quay.io/opstree/redis:latest


### PR DESCRIPTION
This image is multi arch AND does not require auth to registry.redhat.io

See why this is needed: https://github.com/Kuadrant/helm-charts-olm/pull/77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Keycloak database image to a newer PostgreSQL 16 image source.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->