### PR TITLE
fix: Broken output of version scripts

### DIFF
--- a/script/get-all-versions.sh
+++ b/script/get-all-versions.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-command -v jq || { echo "'jq' is required for running this script."; exit 1; }
-command -v opm || { echo "'opm' is required for running this script."; exit 1; }
+command -v jq > /dev/null || { echo "'jq' is required for running this script."; exit 1; }
+command -v opm > /dev/null || { echo "'opm' is required for running this script."; exit 1; }
 
 tmpdir=$(mktemp -d)
 trap "rm -rf $tmpdir" EXIT

--- a/script/get-images-versions.sh
+++ b/script/get-images-versions.sh
@@ -103,7 +103,7 @@ get_latest_tag() {
     echo "$latest"
 }
 
-command -v jq || { echo "'jq' is required for running this script."; exit 1; }
+command -v jq > /dev/null || { echo "'jq' is required for running this script."; exit 1; }
 
 # Fetch all tags in parallel
 tmpdir=$(mktemp -d)

--- a/script/get-operator-versions.sh
+++ b/script/get-operator-versions.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 
 CATALOG_IMAGE="${CATALOG_IMAGE:-registry.redhat.io/redhat/redhat-operator-index:v4.22}"
 
-command -v jq || { echo "'jq' is required for running this script."; exit 1; }
-command -v opm || { echo "'opm' is required for running this script."; exit 1; }
+command -v jq > /dev/null || { echo "'jq' is required for running this script."; exit 1; }
+command -v opm > /dev/null || { echo "'opm' is required for running this script."; exit 1; }
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT


### PR DESCRIPTION
The `command -v ...` has output which interferes with the output. Adding redirect to null as the output is not important.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency checks in version and image retrieval scripts.
  * Missing command-line tools now produce clear errors without displaying successful command output.
  * Existing validation, error messages and exit behaviour remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->