### PR TITLE
feat: Better freeze version handling

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,12 @@ if [[ "$INSTALL_RHCL_GA" == "true" ]]; then
 fi
 
 if [[ "$FREEZE_VERSIONS" == "true" ]]; then
-    script/get-all-versions.sh > "values-versions.yaml" || exit 1
+    if ! [[ -e "values-versions.yaml" ]]; then
+    	script/get-all-versions.sh > "values-versions.yaml" || exit 1;
+    else
+	echo -n "Using privously frozen versions ";
+	head -1 "values-versions.yaml";
+    fi
     additional_flags+=" --values values-versions.yaml"
     tools_additional_flags+=" --values values-versions.yaml"
 fi


### PR DESCRIPTION
Currently when version freezing is enabled by setting var `FREEZE_VERSIONS ="true"` everytime install script is called the versions get re-generated. Changing this to generate only once an re-use existing version values. To re-generate now, one must remove the old `values-versions.yaml` file which seems reasonable to me.