### PR TITLE
revert: Downgrade istio version due to ocp419

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -93,7 +93,7 @@ istio:
   # if left empty no Gateway API implementation is installed
   istioProvider: ossm3
   ossm3:  # Openshift Service Mesh, but version 3
-    version: v1.30-latest
+    version: v1.28-latest
     operator:
       channel: stable
       startingCSV: servicemeshoperator3.v3.4.0  # Ignored if 'Automatic' bellow


### PR DESCRIPTION
Still supported ocp419 has ossm3 which doesnt support newest istio yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the Istio/operator version used by the OSSM3 Gateway API provider to `v1.28-latest`.
  * Existing operator channel and installation plan settings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->